### PR TITLE
fix: use event name to set isPrerelease

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -45,7 +45,7 @@ export default async function main() {
     return;
   }
 
-  if(!GITHUB_EVENT_NAME) {
+  if (!GITHUB_EVENT_NAME) {
     core.setFailed('Missing GITHUB_EVENT_NAME');
     return;
   }
@@ -64,9 +64,8 @@ export default async function main() {
     .split(',')
     .some((branch) => currentBranch.match(branch));
   const isPullRequest = isPr(GITHUB_EVENT_NAME);
-  const isPrerelease = !isReleaseBranch && (
-    isPullRequest || isPreReleaseBranch
-  );
+  const isPrerelease =
+    !isReleaseBranch && (isPullRequest || isPreReleaseBranch);
 
   // Sanitize identifier according to
   // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions

--- a/src/action.ts
+++ b/src/action.ts
@@ -64,7 +64,7 @@ export default async function main() {
     .split(',')
     .some((branch) => currentBranch.match(branch));
   const isPullRequest = isPr(GITHUB_EVENT_NAME);
-  const isPrerelease = !isReleaseBranch && !isPullRequest && isPreReleaseBranch;
+  const isPrerelease = !isReleaseBranch && (isPullRequest || isPreReleaseBranch);
 
   // Sanitize identifier according to
   // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions

--- a/src/action.ts
+++ b/src/action.ts
@@ -64,7 +64,9 @@ export default async function main() {
     .split(',')
     .some((branch) => currentBranch.match(branch));
   const isPullRequest = isPr(GITHUB_EVENT_NAME);
-  const isPrerelease = !isReleaseBranch && (isPullRequest || isPreReleaseBranch);
+  const isPrerelease = !isReleaseBranch && (
+    isPullRequest || isPreReleaseBranch
+  );
 
   // Sanitize identifier according to
   // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions

--- a/src/action.ts
+++ b/src/action.ts
@@ -38,10 +38,15 @@ export default async function main() {
     mappedReleaseRules = mapCustomReleaseRules(customReleaseRules);
   }
 
-  const { GITHUB_REF, GITHUB_SHA } = process.env;
+  const { GITHUB_REF, GITHUB_SHA, GITHUB_EVENT_NAME } = process.env;
 
   if (!GITHUB_REF) {
     core.setFailed('Missing GITHUB_REF.');
+    return;
+  }
+
+  if(!GITHUB_EVENT_NAME) {
+    core.setFailed('Missing GITHUB_EVENT_NAME');
     return;
   }
 
@@ -58,7 +63,7 @@ export default async function main() {
   const isPreReleaseBranch = preReleaseBranches
     .split(',')
     .some((branch) => currentBranch.match(branch));
-  const isPullRequest = isPr(GITHUB_REF);
+  const isPullRequest = isPr(GITHUB_EVENT_NAME);
   const isPrerelease = !isReleaseBranch && !isPullRequest && isPreReleaseBranch;
 
   // Sanitize identifier according to

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,8 +49,8 @@ export function getBranchFromRef(ref: string) {
   return ref.replace('refs/heads/', '');
 }
 
-export function isPr(ref: string) {
-  return ref.includes('refs/pull/');
+export function isPr(eventName: string) {
+  return eventName.includes('pull_request');
 }
 
 export function getLatestTag(

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -8,7 +8,7 @@ import {
   setCommitSha,
   setInput,
   setRepository,
-  setEventName
+  setEventName,
 } from './helper.test';
 
 jest.spyOn(core, 'debug').mockImplementation(() => {});

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -769,6 +769,10 @@ describe('github-tag-action', () => {
         .spyOn(utils, 'getCommits')
         .mockImplementation(async (sha) => commits);
 
+      jest
+        .spyOn(utils,'getEventName')
+        .mockImplementation('push');
+
       const validTags = [
         {
           name: 'v1.2.3',
@@ -805,7 +809,9 @@ describe('github-tag-action', () => {
       jest
         .spyOn(utils, 'getCommits')
         .mockImplementation(async (sha) => commits);
-
+      jest
+        .spyOn(utils,'getEventName')
+        .mockImplementation('push');
       const validTags = [
         {
           name: 'v1.2.3',
@@ -846,7 +852,10 @@ describe('github-tag-action', () => {
       jest
         .spyOn(utils, 'getCommits')
         .mockImplementation(async (sha) => commits);
-
+      jest
+        .spyOn(utils,'getEventName')
+        .mockImplementation('push');
+        
       const validTags = [
         {
           name: 'v1.2.3',

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -771,7 +771,7 @@ describe('github-tag-action', () => {
 
       jest
         .spyOn(utils,'getEventName')
-        .mockImplementation('push');
+        .mockImplementation((eventName) => 'push');
 
       const validTags = [
         {
@@ -811,7 +811,7 @@ describe('github-tag-action', () => {
         .mockImplementation(async (sha) => commits);
       jest
         .spyOn(utils,'getEventName')
-        .mockImplementation('push');
+        .mockImplementation((eventName) => 'push');
       const validTags = [
         {
           name: 'v1.2.3',
@@ -854,8 +854,8 @@ describe('github-tag-action', () => {
         .mockImplementation(async (sha) => commits);
       jest
         .spyOn(utils,'getEventName')
-        .mockImplementation('push');
-        
+        .mockImplementation((eventName) => 'push');
+
       const validTags = [
         {
           name: 'v1.2.3',

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -8,6 +8,7 @@ import {
   setCommitSha,
   setInput,
   setRepository,
+  setEventName
 } from './helper.test';
 
 jest.spyOn(core, 'debug').mockImplementation(() => {});
@@ -33,6 +34,7 @@ describe('github-tag-action', () => {
     jest.clearAllMocks();
     setBranch('master');
     setCommitSha('79e0ea271c26aa152beef77c3275ff7b8f8d8274');
+    setEventName('push');
     loadDefaultInputs();
   });
 
@@ -769,10 +771,6 @@ describe('github-tag-action', () => {
         .spyOn(utils, 'getCommits')
         .mockImplementation(async (sha) => commits);
 
-      jest
-        .spyOn(utils,'getEventName')
-        .mockImplementation((eventName) => 'push');
-
       const validTags = [
         {
           name: 'v1.2.3',
@@ -809,9 +807,7 @@ describe('github-tag-action', () => {
       jest
         .spyOn(utils, 'getCommits')
         .mockImplementation(async (sha) => commits);
-      jest
-        .spyOn(utils,'getEventName')
-        .mockImplementation((eventName) => 'push');
+
       const validTags = [
         {
           name: 'v1.2.3',
@@ -852,9 +848,6 @@ describe('github-tag-action', () => {
       jest
         .spyOn(utils, 'getCommits')
         .mockImplementation(async (sha) => commits);
-      jest
-        .spyOn(utils,'getEventName')
-        .mockImplementation((eventName) => 'push');
 
       const validTags = [
         {

--- a/tests/helper.test.ts
+++ b/tests/helper.test.ts
@@ -18,6 +18,10 @@ export function setCommitSha(sha: string) {
   process.env['GITHUB_SHA'] = sha;
 }
 
+export function getEventName(eventName: string) {
+  process.env['GITHUB_EVENT_NAME'] = eventName;
+}
+
 export function setInput(key: string, value: string) {
   process.env[`INPUT_${key.toUpperCase()}`] = value;
 }

--- a/tests/helper.test.ts
+++ b/tests/helper.test.ts
@@ -18,7 +18,7 @@ export function setCommitSha(sha: string) {
   process.env['GITHUB_SHA'] = sha;
 }
 
-export function getEventName(eventName: string) {
+export function setEventName(eventName: string) {
   process.env['GITHUB_EVENT_NAME'] = eventName;
 }
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -31,12 +31,12 @@ describe('utils', () => {
     /*
      * Given
      */
-    const remoteRef = 'refs/pull/123/merge';
+    const eventName = 'pull_request';
 
     /*
      * When
      */
-    const isPullRequest = utils.isPr(remoteRef);
+    const isPullRequest = utils.isPr(eventName);
 
     /*
      * Then

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -27,7 +27,7 @@ describe('utils', () => {
     expect(branch).toEqual('master');
   });
 
-  it('test if ref is PR', () => {
+  it('test if triggering event is PR', () => {
     /*
      * Given
      */


### PR DESCRIPTION
Use GITHUB_EVENT_NAME environment variable to determine if the triggering event was a pull request.