### PR TITLE
feat!: remove pre_release_branch from inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Tag Action
 
-A GitHub Action to automatically bump and tag master, on merge, with the latest SemVer formatted version. Works on any platform.
+A GitHub Action to automatically bump and tag a repository with the latest SemVer formatted version on pushes to release branch. Can be used to generate pre-release tags on any other branches. Works on any platform.
 
 ## Usage
 
@@ -40,7 +40,6 @@ jobs:
 #### Filter branches
 
 - **release_branches** _(optional)_ - Comma separated list of branches (JavaScript regular expression accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any repository tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`... (default: `master,main`).
-- **pre_release_branches** _(optional)_ - Comma separated list of branches (JavaScript regular expression accepted) that will generate the pre-release tags.
 
 #### Customize the tag
 
@@ -49,7 +48,8 @@ jobs:
 - **custom_tag** _(optional)_ - Custom tag name. If specified, it overrides bump settings.
 - **create_annotated_tag** _(optional)_ - Boolean to create an annotated rather than a lightweight one (default: `false`).
 - **tag_prefix** _(optional)_ - A prefix to the tag name (default: `v`).
-- **append_to_pre_release_tag** _(optional)_ - A suffix to the pre-release tag name (default: `<branch>`).
+- **append_to_pre_release_tag** _(optional)_ - A suffix to the pre-release tag name (default: `beta`).
+- **append_commit_sha** _(optional)_ - Boolean to override append_to_pre_release_tag with usage of the commit sha as identifier. (default: false).
 
 #### Customize the conventional commit messages & titles of changelog sections
 
@@ -129,4 +129,5 @@ If no commit message contains any information, then **default_bump** will be use
 
 ## Credits
 
+[mathieudutour/github-tag-action](https://github.com/mathieudutour/github-tag-action) - action which this repository was orignially forked from
 [anothrNick/github-tag-action](https://github.com/anothrNick/github-tag-action) - a similar action using a Dockerfile (hence not working on macOS)

--- a/action.yml
+++ b/action.yml
@@ -42,9 +42,10 @@ inputs:
     description: "Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`..."
     required: false
     default: "master,main"
-  commit_sha:
-    description: "The commit SHA value to add the tag. If specified, it uses this value instead GITHUB_SHA. It could be useful when a previous step merged a branch into github.ref."
+  append_commit_sha:
+    description: "Boolean to override append_to_prerelease_tag with the commit sha. Appends commit sha at the end of prerelease tags. (default: false)"
     required: false
+    default: "false"
   create_annotated_tag:
     description: "Boolean to create an annotated tag rather than lightweight."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,8 @@ inputs:
     required: false
     default: "v"
   append_to_pre_release_tag:
-    description: "A suffix to a pre-release tag name (default: `<branch>`)."
+    description: "A suffix to a pre-release tag name (default: `beta`)."
+    default: "beta"
     required: false
   custom_tag:
     description: "Custom tag name. If specified, it overrides bump settings."
@@ -41,9 +42,6 @@ inputs:
     description: "Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`..."
     required: false
     default: "master,main"
-  pre_release_branches:
-    description: "Comma separated list of branches (bash reg exp accepted) that will generate pre-release tags."
-    required: false
   commit_sha:
     description: "The commit SHA value to add the tag. If specified, it uses this value instead GITHUB_SHA. It could be useful when a previous step merged a branch into github.ref."
     required: false

--- a/lib/action.js
+++ b/lib/action.js
@@ -1,7 +1,11 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -83,10 +87,10 @@ function main() {
             .some((branch) => currentBranch.match(branch));
         const isPreReleaseBranch = (0, utils_1.isPrereleaseBranch)(preReleaseBranches, currentBranch);
         const isPullRequest = (0, utils_1.isPr)(GITHUB_EVENT_NAME);
-        const isPrerelease = !isReleaseBranch && !isPullRequest && isPreReleaseBranch;
+        const isPrerelease = !isReleaseBranch || isPullRequest;
         // Sanitize identifier according to
         // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
-        const identifier = (0, utils_1.getIdentifier)(appendToPreReleaseTag, currentBranch, isPullRequest, isPrerelease, commitRef);
+        const identifier = (0, utils_1.getIdentifier)(appendToPreReleaseTag, currentBranch, isPrerelease, commitRef);
         const prefixRegex = new RegExp(`^${tagPrefix}`);
         const validTags = yield (0, utils_1.getValidTags)(prefixRegex, /true/i.test(shouldFetchAllTags));
         const latestTag = (0, utils_1.getLatestTag)(validTags, prefixRegex, tagPrefix);
@@ -170,12 +174,7 @@ function main() {
                 core.setFailed(`${incrementedVersion} is not a valid semver.`);
                 return;
             }
-            if (isPullRequest) {
-                newVersion = `${incrementedVersion}-${identifier}`;
-            }
-            else {
-                newVersion = incrementedVersion;
-            }
+            newVersion = incrementedVersion;
         }
         core.info(`New version is ${newVersion}.`);
         core.setOutput('new_version', newVersion);
@@ -198,10 +197,6 @@ function main() {
         });
         core.info(`Changelog is ${changelog}.`);
         core.setOutput('changelog', changelog);
-        if (!isReleaseBranch && !isPreReleaseBranch) {
-            core.info('This branch is neither a release nor a pre-release branch. Skipping the tag creation.');
-            return;
-        }
         if (validTags.map((tag) => tag.name).includes(newTag)) {
             core.info('This tag already exists. Skipping the tag creation.');
             return;

--- a/lib/github.js
+++ b/lib/github.js
@@ -1,7 +1,11 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,11 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,11 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -135,14 +139,10 @@ function mergeWithDefaultChangelogRules(mappedReleaseRules = []) {
     return Object.values(mergedRules).filter((rule) => !!rule.section);
 }
 exports.mergeWithDefaultChangelogRules = mergeWithDefaultChangelogRules;
-function getIdentifier(appendToPreReleaseTag, currentBranch, isPullRequest, isPrerelease, commitRef) {
+function getIdentifier(appendToPreReleaseTag, currentBranch, isPrerelease, commitRef) {
     // On prerelease: Sanitize identifier according to
     // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
     let identifier;
-    if (isPullRequest) {
-        // On pull request, use commit SHA for identifier
-        return commitRef.slice(0, 7).replace(/[^a-zA-Z0-9-]/g, '-');
-    }
     identifier = (appendToPreReleaseTag ? appendToPreReleaseTag : currentBranch).replace(/[^a-zA-Z0-9-]/g, '-');
     return identifier;
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -5,7 +5,6 @@ import { generateNotes } from '@semantic-release/release-notes-generator';
 import {
   getBranchFromRef,
   isPr,
-  isPrereleaseBranch,
   getCommits,
   getLatestPrereleaseTag,
   getLatestTag,
@@ -25,7 +24,7 @@ export default async function main() {
   const tagPrefix = core.getInput('tag_prefix');
   const customTag = core.getInput('custom_tag');
   const releaseBranches = core.getInput('release_branches');
-  const preReleaseBranches = core.getInput('pre_release_branches');
+  const appendCommitRef = core.getBooleanInput('append_commit_sha');
   const appendToPreReleaseTag = core.getInput('append_to_pre_release_tag');
   const createAnnotatedTag = /true/i.test(
     core.getInput('create_annotated_tag')
@@ -62,10 +61,6 @@ export default async function main() {
   const isReleaseBranch = releaseBranches
     .split(',')
     .some((branch) => currentBranch.match(branch));
-  const isPreReleaseBranch = isPrereleaseBranch(
-    preReleaseBranches,
-    currentBranch
-  );
   const isPullRequest = isPr(GITHUB_EVENT_NAME);
   const isPrerelease = !isReleaseBranch || isPullRequest;
 
@@ -73,8 +68,7 @@ export default async function main() {
   // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
   const identifier = getIdentifier(
     appendToPreReleaseTag,
-    currentBranch,
-    isPrerelease,
+    appendCommitRef,
     commitRef
   );
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -154,15 +154,14 @@ export function mergeWithDefaultChangelogRules(
 
 export function getIdentifier(
   appendToPreReleaseTag: string,
-  currentBranch: string,
-  isPrerelease: boolean,
+  appendCommitRef: boolean,
   commitRef: string
 ): string {
   // On prerelease: Sanitize identifier according to
   // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
   let identifier: string;
   identifier = (
-    appendToPreReleaseTag ? appendToPreReleaseTag : currentBranch
+    appendCommitRef ?  commitRef.slice(0,7) : appendToPreReleaseTag
   ).replace(/[^a-zA-Z0-9-]/g, '-');
   return identifier;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -161,8 +161,8 @@ export function getIdentifier(
   // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
   let identifier: string;
   identifier = (
-    appendCommitRef ?  commitRef.slice(0,7) : appendToPreReleaseTag
+    appendCommitRef ? commitRef.slice(0, 7) : appendToPreReleaseTag
   ).replace(/[^a-zA-Z0-9-]/g, '-');
-  console.log(identifier)
+  console.log(identifier);
   return identifier;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -163,5 +163,6 @@ export function getIdentifier(
   identifier = (
     appendCommitRef ?  commitRef.slice(0,7) : appendToPreReleaseTag
   ).replace(/[^a-zA-Z0-9-]/g, '-');
+  console.log(identifier)
   return identifier;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,17 +155,12 @@ export function mergeWithDefaultChangelogRules(
 export function getIdentifier(
   appendToPreReleaseTag: string,
   currentBranch: string,
-  isPullRequest: boolean,
   isPrerelease: boolean,
   commitRef: string
 ): string {
   // On prerelease: Sanitize identifier according to
   // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
   let identifier: string;
-  if (isPullRequest) {
-    // On pull request, use commit SHA for identifier
-    return commitRef.slice(0, 7).replace(/[^a-zA-Z0-9-]/g, '-');
-  }
   identifier = (
     appendToPreReleaseTag ? appendToPreReleaseTag : currentBranch
   ).replace(/[^a-zA-Z0-9-]/g, '-');

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -762,7 +762,7 @@ describe('github-tag-action', () => {
       setBranch('development');
     });
 
-    it('does output patch tag', async () => {
+    it('does output prepatch tag', async () => {
       /*
        * Given
        */
@@ -797,7 +797,7 @@ describe('github-tag-action', () => {
       expect(mockSetFailed).not.toBeCalled();
     });
 
-    it('does output minor tag', async () => {
+    it('does output preminor tag', async () => {
       /*
        * Given
        */
@@ -834,7 +834,7 @@ describe('github-tag-action', () => {
       expect(mockSetFailed).not.toBeCalled();
     });
 
-    it('does output major tag', async () => {
+    it('does output premajor tag', async () => {
       /*
        * Given
        */
@@ -876,11 +876,12 @@ describe('github-tag-action', () => {
     });
   });
 
-  describe('pull requests', () => {
+  describe('commit sha suffix', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       setBranch('branch-with-my-first-fix');
       setEventName('pull_request');
+      setInput('append_commit_sha','true');
     });
 
     it('does create new version with commit sha suffix on pull request', async () => {

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -916,9 +916,9 @@ describe('github-tag-action', () => {
        */
       expect(mockSetOutput).toHaveBeenCalledWith(
         'new_version',
-        `1.2.4-${commitSha.slice(0, 7)}`
+        `1.2.4-${commitSha.slice(0, 7)}.0`
       );
-      expect(mockCreateTag).toHaveBeenCalledWith();
+      expect(mockCreateTag).not.toHaveBeenCalledWith();
       expect(mockSetFailed).not.toBeCalled();
     });
   });

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -34,7 +34,7 @@ describe('github-tag-action', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     setBranch('master');
-    setInput('release_branches','master,main');
+    setInput('release_branches', 'master,main');
     setCommitSha(commitSha);
     setEventName('push');
     loadDefaultInputs();
@@ -881,7 +881,7 @@ describe('github-tag-action', () => {
       jest.clearAllMocks();
       setBranch('branch-with-my-first-fix');
       setEventName('pull_request');
-      setInput('append_commit_sha','true');
+      setInput('append_commit_sha', 'true');
     });
 
     it('does create new version with commit sha suffix on pull request', async () => {

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -224,7 +224,7 @@ describe('github-tag-action', () => {
   describe('release branches', () => {
     beforeEach(() => {
       jest.clearAllMocks();
-      setBranch('release');
+      setBranch('master');
       setEventName('push');
     });
 

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -918,7 +918,7 @@ describe('github-tag-action', () => {
         'new_version',
         `1.2.4-${commitSha.slice(0, 7)}`
       );
-      expect(mockCreateTag).not.toHaveBeenCalledWith();
+      expect(mockCreateTag).toHaveBeenCalledWith();
       expect(mockSetFailed).not.toBeCalled();
     });
   });

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -793,7 +793,7 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockSetOutput).toHaveBeenCalledWith('new_version', '1.2.4-beta.0');
-      expect(mockCreateTag).not.toBeCalled();
+      expect(mockCreateTag).toBeCalled();
       expect(mockSetFailed).not.toBeCalled();
     });
 
@@ -830,7 +830,7 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockSetOutput).toHaveBeenCalledWith('new_version', '1.3.0-beta.0');
-      expect(mockCreateTag).not.toBeCalled();
+      expect(mockCreateTag).toBeCalled();
       expect(mockSetFailed).not.toBeCalled();
     });
 
@@ -871,7 +871,7 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockSetOutput).toHaveBeenCalledWith('new_version', '2.0.0-beta.0');
-      expect(mockCreateTag).not.toBeCalled();
+      expect(mockCreateTag).toBeCalled();
       expect(mockSetFailed).not.toBeCalled();
     });
   });

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -34,6 +34,7 @@ describe('github-tag-action', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     setBranch('master');
+    setInput('release_branches','master,main');
     setCommitSha(commitSha);
     setEventName('push');
     loadDefaultInputs();
@@ -224,7 +225,6 @@ describe('github-tag-action', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       setBranch('release');
-      setInput('release_branches', 'release');
       setEventName('push');
     });
 
@@ -397,7 +397,7 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockCreateTag).toHaveBeenCalledWith(
-        'v1.3.0',
+        'v2.2.0',
         expect.any(Boolean),
         expect.any(String)
       );
@@ -454,7 +454,6 @@ describe('github-tag-action', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       setBranch('prerelease');
-      setInput('release_branches', 'release');
     });
 
     it('does not create tag without commits and default_bump set to false', async () => {
@@ -761,7 +760,6 @@ describe('github-tag-action', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       setBranch('development');
-      setInput('release_branches', 'release');
     });
 
     it('does output patch tag', async () => {

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -792,7 +792,7 @@ describe('github-tag-action', () => {
       /*
        * Then
        */
-      expect(mockSetOutput).toHaveBeenCalledWith('new_version', '1.2.4');
+      expect(mockSetOutput).toHaveBeenCalledWith('new_version', '1.2.4-beta.0');
       expect(mockCreateTag).not.toBeCalled();
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -829,7 +829,7 @@ describe('github-tag-action', () => {
       /*
        * Then
        */
-      expect(mockSetOutput).toHaveBeenCalledWith('new_version', '1.3.0');
+      expect(mockSetOutput).toHaveBeenCalledWith('new_version', '1.3.0-beta.0');
       expect(mockCreateTag).not.toBeCalled();
       expect(mockSetFailed).not.toBeCalled();
     });
@@ -870,7 +870,7 @@ describe('github-tag-action', () => {
       /*
        * Then
        */
-      expect(mockSetOutput).toHaveBeenCalledWith('new_version', '2.0.0');
+      expect(mockSetOutput).toHaveBeenCalledWith('new_version', '2.0.0-beta.0');
       expect(mockCreateTag).not.toBeCalled();
       expect(mockSetFailed).not.toBeCalled();
     });

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -370,14 +370,14 @@ describe('github-tag-action', () => {
           node_id: 'string',
         },
         {
-          name: 'v2.1.3-prerelease.0',
+          name: 'v2.1.3-beta.0',
           commit: { sha: '678901', url: '' },
           zipball_url: '',
           tarball_url: 'string',
           node_id: 'string',
         },
         {
-          name: 'v2.1.3-prerelease.1',
+          name: 'v2.1.3-beta.1',
           commit: { sha: '234567', url: '' },
           zipball_url: '',
           tarball_url: 'string',
@@ -397,7 +397,7 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockCreateTag).toHaveBeenCalledWith(
-        'v2.2.0',
+        'v1.3.0',
         expect.any(Boolean),
         expect.any(String)
       );
@@ -454,7 +454,7 @@ describe('github-tag-action', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       setBranch('prerelease');
-      setInput('pre_release_branches', 'prerelease');
+      setInput('release_branches', 'release');
     });
 
     it('does not create tag without commits and default_bump set to false', async () => {
@@ -525,7 +525,7 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockCreateTag).toHaveBeenCalledWith(
-        'v1.2.4-prerelease.0',
+        'v1.2.4-beta.0',
         expect.any(Boolean),
         expect.any(String)
       );
@@ -563,7 +563,7 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockCreateTag).toHaveBeenCalledWith(
-        'v1.2.4-prerelease.0',
+        'v1.2.4-beta.0',
         expect.any(Boolean),
         expect.any(String)
       );
@@ -603,7 +603,7 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockCreateTag).toHaveBeenCalledWith(
-        'v1.3.0-prerelease.0',
+        'v1.3.0-beta.0',
         expect.any(Boolean),
         expect.any(String)
       );
@@ -647,7 +647,7 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockCreateTag).toHaveBeenCalledWith(
-        'v2.0.0-prerelease.0',
+        'v2.0.0-beta.0',
         expect.any(Boolean),
         expect.any(String)
       );
@@ -670,14 +670,14 @@ describe('github-tag-action', () => {
 
       const validTags = [
         {
-          name: 'v1.2.3-prerelease.0',
+          name: 'v1.2.3-beta.0',
           commit: { sha: '012345', url: '' },
           zipball_url: '',
           tarball_url: 'string',
           node_id: 'string',
         },
         {
-          name: 'v3.1.2-feature.0',
+          name: 'v3.1.2-beta.0',
           commit: { sha: '012345', url: '' },
           zipball_url: '',
           tarball_url: 'string',
@@ -704,7 +704,7 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockCreateTag).toHaveBeenCalledWith(
-        'v2.2.0-prerelease.0',
+        'v2.2.0-beta.0',
         expect.any(Boolean),
         expect.any(String)
       );
@@ -749,7 +749,7 @@ describe('github-tag-action', () => {
        * Then
        */
       expect(mockCreateTag).toHaveBeenCalledWith(
-        'v1.3.0-prerelease.0',
+        'v1.3.0-beta.0',
         expect.any(Boolean),
         expect.any(String)
       );
@@ -761,7 +761,6 @@ describe('github-tag-action', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       setBranch('development');
-      setInput('pre_release_branches', 'prerelease');
       setInput('release_branches', 'release');
     });
 


### PR DESCRIPTION
- Remove pre_release_branch as input with the intent of any branch that is not release branch should be treated as a prerelease branch.
- Add optional input for commit sha as identifier
- Treat all branches that are not release branch as a prerelease branch. Use dry_run if no tag should be generated. 