### PR TITLE
fix: generate changelog based on latest release

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -24,7 +24,9 @@ export default async function main() {
   const tagPrefix = core.getInput('tag_prefix');
   const customTag = core.getInput('custom_tag');
   const releaseBranches = core.getInput('release_branches');
-  const appendCommitRef = core.getBooleanInput('append_commit_sha');
+  const appendCommitRef = /true/i.test(
+    core.getInput('append_commit_sha')
+  );
   const appendToPreReleaseTag = core.getInput('append_to_pre_release_tag');
   const createAnnotatedTag = /true/i.test(
     core.getInput('create_annotated_tag')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,7 +71,7 @@ export function getLatestTag(
   tagPrefix: string
 ) {
   return (
-    tags.find((tag) => !prerelease(tag.name.replace(prefixRegex, ''))) && {
+    tags.find((tag) => !prerelease(tag.name.replace(prefixRegex, ''))) || {
       name: `${tagPrefix}0.0.0`,
       commit: {
         sha: 'HEAD',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,7 +71,7 @@ export function getLatestTag(
   tagPrefix: string
 ) {
   return (
-    tags.find((tag) => !prerelease(tag.name.replace(prefixRegex, ''))) || {
+    tags.find((tag) => !prerelease(tag.name.replace(prefixRegex, ''))) && {
       name: `${tagPrefix}0.0.0`,
       commit: {
         sha: 'HEAD',


### PR DESCRIPTION
Currently release logs were based on changes since last prerelease. This will generate the full release log since last release.