### PR TITLE
feat!: remove trailing chars after commit sha identifier

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -88,7 +88,8 @@ function main() {
         core.info(`Commit ref: ${commitRef}`);
         core.info(`Use commit ref as identifier: ${appendCommitRef}`);
         core.info(`Append to prerelease version if not commit ref: ${appendToPreReleaseTag}`);
-        const identifier = (0, utils_1.getIdentifier)(appendToPreReleaseTag, appendCommitRef, commitRef);
+        const shortenedCommitRef = commitRef.slice(0, 7);
+        const identifier = (0, utils_1.getIdentifier)(appendToPreReleaseTag, appendCommitRef, shortenedCommitRef);
         core.info(`Prerelease identifier: ${identifier}`);
         const prefixRegex = new RegExp(`^${tagPrefix}`);
         const validTags = yield (0, utils_1.getValidTags)(prefixRegex, /true/i.test(shouldFetchAllTags));
@@ -174,6 +175,9 @@ function main() {
                 return;
             }
             newVersion = incrementedVersion;
+            if (appendCommitRef) {
+                newVersion = newVersion.substring(0, newVersion.lastIndexOf(shortenedCommitRef));
+            }
         }
         core.info(`New version is ${newVersion}.`);
         core.setOutput('new_version', newVersion);

--- a/lib/action.js
+++ b/lib/action.js
@@ -85,10 +85,10 @@ function main() {
         const isPrerelease = !isReleaseBranch || isPullRequest;
         // Sanitize identifier according to
         // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
-        core.info(`Commit ref: ${commitRef}`);
         core.info(`Use commit ref as identifier: ${appendCommitRef}`);
         core.info(`Append to prerelease version if not commit ref: ${appendToPreReleaseTag}`);
         const shortenedCommitRef = commitRef.slice(0, 7);
+        core.info(`Commit ref: ${commitRef}, shortened commitRef: ${shortenedCommitRef}`);
         const identifier = (0, utils_1.getIdentifier)(appendToPreReleaseTag, appendCommitRef, shortenedCommitRef);
         core.info(`Prerelease identifier: ${identifier}`);
         const prefixRegex = new RegExp(`^${tagPrefix}`);
@@ -176,7 +176,9 @@ function main() {
             }
             newVersion = incrementedVersion;
             if (appendCommitRef) {
-                newVersion = newVersion.substring(0, newVersion.lastIndexOf(shortenedCommitRef));
+                console.log(`Use only shortenedCommitRef as identifier. Remove trailing characters from ${newVersion}`);
+                newVersion = newVersion.substring(0, newVersion.lastIndexOf(shortenedCommitRef) + shortenedCommitRef.length);
+                console.log(`newVersion: ${newVersion}`);
             }
         }
         core.info(`New version is ${newVersion}.`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -139,7 +139,7 @@ function getIdentifier(appendToPreReleaseTag, appendCommitRef, commitRef) {
     // On prerelease: Sanitize identifier according to
     // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
     let identifier;
-    identifier = (appendCommitRef ? commitRef.slice(0, 7) : appendToPreReleaseTag).replace(/[^a-zA-Z0-9-]/g, '-');
+    identifier = (appendCommitRef ? commitRef : appendToPreReleaseTag).replace(/[^a-zA-Z0-9-]/g, '-');
     console.log(identifier);
     return identifier;
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -66,12 +66,15 @@ export default async function main() {
 
   // Sanitize identifier according to
   // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
-  core.info(`Commit ref: ${commitRef}`);
+
   core.info(`Use commit ref as identifier: ${appendCommitRef}`);
   core.info(
     `Append to prerelease version if not commit ref: ${appendToPreReleaseTag}`
   );
   const shortenedCommitRef = commitRef.slice(0, 7);
+  core.info(
+    `Commit ref: ${commitRef}, shortened commitRef: ${shortenedCommitRef}`
+  );
   const identifier = getIdentifier(
     appendToPreReleaseTag,
     appendCommitRef,
@@ -194,10 +197,14 @@ export default async function main() {
     }
     newVersion = incrementedVersion;
     if (appendCommitRef) {
+      console.log(
+        `Use only shortenedCommitRef as identifier. Remove trailing characters from ${newVersion}`
+      );
       newVersion = newVersion.substring(
         0,
-        newVersion.lastIndexOf(shortenedCommitRef)
+        newVersion.lastIndexOf(shortenedCommitRef) + shortenedCommitRef.length
       );
+      console.log(`newVersion: ${newVersion}`);
     }
   }
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -71,10 +71,11 @@ export default async function main() {
   core.info(
     `Append to prerelease version if not commit ref: ${appendToPreReleaseTag}`
   );
+  const shortenedCommitRef = commitRef.slice(0, 7);
   const identifier = getIdentifier(
     appendToPreReleaseTag,
     appendCommitRef,
-    commitRef
+    shortenedCommitRef
   );
   core.info(`Prerelease identifier: ${identifier}`);
   const prefixRegex = new RegExp(`^${tagPrefix}`);
@@ -192,6 +193,12 @@ export default async function main() {
       return;
     }
     newVersion = incrementedVersion;
+    if (appendCommitRef) {
+      newVersion = newVersion.substring(
+        0,
+        newVersion.lastIndexOf(shortenedCommitRef)
+      );
+    }
   }
 
   core.info(`New version is ${newVersion}.`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -160,9 +160,10 @@ export function getIdentifier(
   // On prerelease: Sanitize identifier according to
   // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
   let identifier: string;
-  identifier = (
-    appendCommitRef ? commitRef.slice(0, 7) : appendToPreReleaseTag
-  ).replace(/[^a-zA-Z0-9-]/g, '-');
+  identifier = (appendCommitRef ? commitRef : appendToPreReleaseTag).replace(
+    /[^a-zA-Z0-9-]/g,
+    '-'
+  );
   console.log(identifier);
   return identifier;
 }

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -916,7 +916,7 @@ describe('github-tag-action', () => {
        */
       expect(mockSetOutput).toHaveBeenCalledWith(
         'new_version',
-        `1.2.4-${commitSha.slice(0, 7)}.0`
+        `1.2.4-${commitSha.slice(0, 7)}`
       );
       expect(mockCreateTag).not.toHaveBeenCalledWith();
       expect(mockSetFailed).not.toBeCalled();


### PR DESCRIPTION
Commit sha identifier no longer has the trailing "." after the commit sha on generated versions.